### PR TITLE
task: [SRE-8091] Update self-hosted syntax

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,8 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: self-hosted
+    runs-on:
+      group: cc-self-hosted
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR updates the 'runs-on' syntax to use 'cc-self-hosted' group.